### PR TITLE
Decorate event before pushing into queue

### DIFF
--- a/lib/logstash/inputs/jmx.rb
+++ b/lib/logstash/inputs/jmx.rb
@@ -191,6 +191,7 @@ class LogStash::Inputs::Jmx < LogStash::Inputs::Base
       event['metric_path'] = metric_path_substituted
       event['metric_value_string'] = metric_value.to_s
     end
+    decorate(event)
     queue << event
   end
 


### PR DESCRIPTION
@talevy a last one to cover an old PR done against logstash-contrib, really sorry too difficult to add test at this stage.

@suyograo after this one is merged, the entry related to jmx input in logstash-contrib can all be closed:
https://github.com/elastic/logstash-contrib/issues/73
https://github.com/elastic/logstash-contrib/pull/62
https://github.com/elastic/logstash-contrib/pull/24
https://github.com/elastic/logstash-contrib/pull/28
https://github.com/elastic/logstash-contrib/issues/128 as duplicate of #8 
