### PR TITLE
Logstash 2.2.1 never stops using logstash-input-jmx-2.0.2 log contains: The shutdown process appears to be stalled due to busy or blocked plugins. Check the logs for more information.

### DIFF
--- a/lib/logstash/inputs/jmx.rb
+++ b/lib/logstash/inputs/jmx.rb
@@ -315,6 +315,8 @@ class LogStash::Inputs::Jmx < LogStash::Inputs::Base
   public
   def run(queue)
     begin
+      @run_thread = Thread.current
+
       threads = []
       @logger.info("Initialize #{@nb_thread} threads for JMX metrics collection")
       @nb_thread.times do
@@ -375,6 +377,7 @@ class LogStash::Inputs::Jmx < LogStash::Inputs::Base
   public
   def stop
     @interrupted = true
+    @run_thread.raise(LogStash::ShutdownSignal) if @run_thread.alive?
   end # def stop
 
   public

--- a/lib/logstash/inputs/jmx.rb
+++ b/lib/logstash/inputs/jmx.rb
@@ -373,6 +373,11 @@ class LogStash::Inputs::Jmx < LogStash::Inputs::Base
   end
 
   public
+  def stop
+    @interrupted = true
+  end # def stop
+
+  public
   def close
     @interrupted = true
   end # def close


### PR DESCRIPTION
{:timestamp=>"2016-02-17T09:28:10.667000+0100", :message=>#<LogStash::PipelineReporter::Snapshot:0x86f90f @data={:events_filtered=>410875, :events_consumed=>410995, :worker_count=>2, :inflight_count=>244, :worker_states=>[{:status=>"run", :alive=>true, :index=>0, :inflight_count=>120}, {:status=>"sleep", :alive=>true, :index=>1, :inflight_count=>124}], :output_info=>[{:type=>"elasticsearch", :config=>{"hosts"=>"localhost"}, :is_multi_worker=>true, :events_received=>410875, :workers=>[<LogStash::Outputs::ElasticSearch hosts=>["localhost"], codec=><LogStash::Codecs::Plain charset=>"UTF-8">, workers=>1, index=>"logstash-%{+YYYY.MM.dd}", manage_template=>true, template_name=>"logstash", template_overwrite=>false, flush_size=>500, idle_flush_time=>1, doc_as_upsert=>false, max_retries=>3, script_type=>"inline", script_var_name=>"event", scripted_upsert=>false, retry_max_interval=>2, retry_max_items=>500, action=>"index", path=>"/", ssl_certificate_verification=>true, sniffing=>false, sniffing_delay=>5>, <LogStash::Outputs::ElasticSearch hosts=>["localhost"], codec=><LogStash::Codecs::Plain charset=>"UTF-8">, workers=>1, index=>"logstash-%{+YYYY.MM.dd}", manage_template=>true, template_name=>"logstash", template_overwrite=>false, flush_size=>500, idle_flush_time=>1, doc_as_upsert=>false, max_retries=>3, script_type=>"inline", script_var_name=>"event", scripted_upsert=>false, retry_max_interval=>2, retry_max_items=>500, action=>"index", path=>"/", ssl_certificate_verification=>true, sniffing=>false, sniffing_delay=>5>], :busy_workers=>0}], :thread_info=>[{"thread_id"=>18, "name"=>"[base]<jmx", "plugin"=>nil, "backtrace"=>["[...]/vendor/bundle/jruby/1.9/gems/logstash-input-jmx-2.0.2/lib/logstash/inputs/jmx.rb:351:in `sleep'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-input-jmx-2.0.2/lib/logstash/inputs/jmx.rb:351:in`run'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:331:in `inputworker'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:325:in`start_input'"], "blocked_on"=>nil, "status"=>"sleep", "current_call"=>"[...]/vendor/bundle/jruby/1.9/gems/logstash-input-jmx-2.0.2/lib/logstash/inputs/jmx.rb:351:in `sleep'"}, {"thread_id"=>35, "name"=>"[base]>worker0", "plugin"=>["LogStash::Filters::Mutate", {"gsub"=>["short_message", "^(.{0,20}).*", "\\1"]}], "backtrace"=>["[...]/vendor/bundle/jruby/1.9/gems/logstash-filter-mutate-2.0.3/lib/logstash/filters/mutate.rb:328:in`gsub'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-filter-mutate-2.0.3/lib/logstash/filters/mutate.rb:311:in `each'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-filter-mutate-2.0.3/lib/logstash/filters/mutate.rb:311:in`gsub'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-filter-mutate-2.0.3/lib/logstash/filters/mutate.rb:221:in `filter'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/filters/base.rb:151:in`multi_filter'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/filters/base.rb:148:in `each'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/filters/base.rb:148:in`multi_filter'", "(eval):160:in `filter_func'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:256:in`filter_batch'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:254:in `inject'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:254:in`filter_batch'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:212:in `worker_loop'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:190:in`start_workers'"], "blocked_on"=>nil, "status"=>"run", "current_call"=>"[...]/vendor/bundle/jruby/1.9/gems/logstash-filter-mutate-2.0.3/lib/logstash/filters/mutate.rb:328:in `gsub'"}, {"thread_id"=>36, "name"=>"[base]>worker1", "plugin"=>["LogStash::Filters::Mutate", {"gsub"=>["short_message", "^(.{0,20}).*", "\\1"]}], "backtrace"=>["[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:298:in`synchronize'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:298:in `inflight_batches_synchronize'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:223:in`worker_loop'", "[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:190:in `start_workers'"], "blocked_on"=>nil, "status"=>"sleep", "current_call"=>"[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:298:in`synchronize'"}], :stalling_threads_info=>[{"thread_id"=>18, "name"=>"[base]<jmx", "plugin"=>nil, "current_call"=>"[...]/vendor/bundle/jruby/1.9/gems/logstash-input-jmx-2.0.2/lib/logstash/inputs/jmx.rb:351:in `sleep'"}, {"thread_id"=>35, "name"=>"[base]>worker0", "plugin"=>["LogStash::Filters::Mutate", {"gsub"=>["short_message", "^(.{0,20}).*", "\\1"]}], "current_call"=>"[...]/vendor/bundle/jruby/1.9/gems/logstash-filter-mutate-2.0.3/lib/logstash/filters/mutate.rb:311:in`each'"}, {"thread_id"=>36, "name"=>"[base]>worker1", "plugin"=>["LogStash::Filters::Mutate", {"gsub"=>["short_message", "^(.{0,20}).*", "\1"]}], "current_call"=>"[...]/vendor/bundle/jruby/1.9/gems/logstash-core-2.2.1-java/lib/logstash/pipeline.rb:298:in `synchronize'"}]}>, :level=>:warn}
{:timestamp=>"2016-02-17T09:28:10.674000+0100", :message=>"The shutdown process appears to be stalled due to busy or blocked plugins. Check the logs for more information.", :level=>:error}
