### PR TITLE
Call event.set, fixes #28

### DIFF
--- a/lib/logstash/inputs/jmx.rb
+++ b/lib/logstash/inputs/jmx.rb
@@ -172,8 +172,8 @@ class LogStash::Inputs::Jmx < LogStash::Inputs::Base
   def send_event_to_queue(queue,host,metric_path,metric_value)
     @logger.debug('Send event to queue to be processed by filters/outputs')
     event = LogStash::Event.new
-    event('host', host)
-    event('path', @path)
+    event.set('host', host)
+    event.set('path', @path)
     event.set('type', @type)
     number_type = [Fixnum, Bignum, Float]
     boolean_type = [TrueClass, FalseClass]


### PR DESCRIPTION
This should resolve issue #28, however, I am currently unable to run the test suite for this plugin at all:

```
 $ jruby -S bundle exec rspec          
You have requested:
  logstash-devutils >= 0

The bundle currently has logstash-devutils locked at 1.1.0.
Try running `bundle update logstash-devutils`

If you are updating multiple gems in your Gemfile at once,
try passing them all to `bundle update`
Run `bundle install` to install missing gems.
```

This error occurs with or without this change.