### PR TITLE
better support for java arrays in values

### DIFF
--- a/lib/logstash/inputs/jmx.rb
+++ b/lib/logstash/inputs/jmx.rb
@@ -189,7 +189,11 @@ class LogStash::Inputs::Jmx < LogStash::Inputs::Base
     else
       @logger.debug("The value #{metric_value} is not of type number: #{metric_value.class}")
       event.set('metric_path', metric_path_substituted)
-      event.set('metric_value_string', metric_value.to_s)
+      if metric_value.java_object.class == Java::JavaArray
+        event.set('metric_value_string', metric_value.to_a.to_s)
+      else
+        event.set('metric_value_string', metric_value.to_s)
+      end
     end
     decorate(event)
     queue << event

--- a/lib/logstash/inputs/jmx.rb
+++ b/lib/logstash/inputs/jmx.rb
@@ -189,7 +189,7 @@ class LogStash::Inputs::Jmx < LogStash::Inputs::Base
     else
       @logger.debug("The value #{metric_value} is not of type number: #{metric_value.class}")
       event.set('metric_path', metric_path_substituted)
-      if metric_value.java_object.class == Java::JavaArray
+      if metric_value.respond_to?(:java_object) && metric_value.java_object.class == Java::JavaArray
         event.set('metric_value_string', metric_value.to_a.to_s)
       else
         event.set('metric_value_string', metric_value.to_s)


### PR DESCRIPTION
Not sure if this is of interest or not, but I tried logstash today and it seems it doesn't properly support values of type array:
`"metric_value_string" => "[J@10425ed8"`
I'd like it to be
`"metric_value_string" => "[0, 0, 0]"`

I don't know jruby and it took a while until I came up with this solution. If it's not clean enough, I'm willing to change it, but I could not find an easy way to check if the value is of type JavaArray.