### PR TITLE
Fix configuration-section headline

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,7 +25,7 @@ Every `polling_frequency`, it scans a folder containing json configuration
 files describing JVMs to monitor with metrics to retrieve.
 Then a pool of threads will retrieve metrics and create events.
 
-## The configuration:
+==== Configuration
 
 In Logstash configuration, you must set the polling frequency,
 the number of thread used to poll metrics and a directory absolute path containing
@@ -155,3 +155,4 @@ Indicate interval between two jmx metrics retrieval
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
+


### PR DESCRIPTION
as it was using invalid asciidoc-syntax and was not shown correctly in the official documentation.
