### PR TITLE
Fix configuration subheading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+  - Fix documentation issue (correct subheading format)
+
 ## 3.0.4
   - Update gemspec summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 3.0.6
+ - Fix documentation issue (correct subheading format)
+
 ## 3.0.5
-  - Fix documentation issue (correct subheading format)
+ - Docs: Set the default_codec doc attribute.
 
 ## 3.0.4
   - Update gemspec summary

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,7 +25,7 @@ Every `polling_frequency`, it scans a folder containing json configuration
 files describing JVMs to monitor with metrics to retrieve.
 Then a pool of threads will retrieve metrics and create events.
 
-## The configuration:
+==== The configuration:
 
 In Logstash configuration, you must set the polling frequency,
 the number of thread used to poll metrics and a directory absolute path containing

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,7 +25,7 @@ Every `polling_frequency`, it scans a folder containing json configuration
 files describing JVMs to monitor with metrics to retrieve.
 Then a pool of threads will retrieve metrics and create events.
 
-==== The configuration:
+==== The configuration
 
 In Logstash configuration, you must set the polling frequency,
 the number of thread used to poll metrics and a directory absolute path containing

--- a/logstash-input-jmx.gemspec
+++ b/logstash-input-jmx.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jmx'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Retrieves metrics from remote Java applications over JMX"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-jmx.gemspec
+++ b/logstash-input-jmx.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jmx'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Retrieves metrics from remote Java applications over JMX"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The section head for Configuration was formatted incorrectly and rendering as "## The configuration."  Fix asciidoc formatting to render as a proper heading. 
