### PR TITLE
fix input plugin shutdown handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+ - Fixed shutdown handling [#47](https://github.com/logstash-plugins/logstash-input-jmx/pull/47)
+
 ## 3.0.6
  - Fix documentation issue (correct subheading format)
 

--- a/logstash-input-jmx.gemspec
+++ b/logstash-input-jmx.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-jmx'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Retrieves metrics from remote Java applications over JMX"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jmx_spec.rb
+++ b/spec/inputs/jmx_spec.rb
@@ -12,6 +12,10 @@ describe LogStash::Inputs::Jmx do
     FileUtils.remove_dir(jmx_config_path)
   end
 
+  it_behaves_like "an interruptible input plugin" do
+    let(:config) {{"path" => jmx_config_path, "nb_thread" => 1, "polling_frequency" => 1}}
+  end
+
   subject { LogStash::Inputs::Jmx.new("path" => jmx_config_path)}
 
   context "#validate_configuration(conf_hash)" do
@@ -83,6 +87,7 @@ describe LogStash::Inputs::Jmx do
     subject { LogStash::Inputs::Jmx.new("path" => jmx_config_path, "nb_thread" => 1, "polling_frequency" => 1)}
 
     let(:queue) { Queue.new }
+
     it "pass host/port connection parameters to jmx4r" do
       File.open(File.join(jmx_config_path,"my.config.json"), "wb") { |file|  file.write(<<-EOT)
       {
@@ -100,7 +105,7 @@ describe LogStash::Inputs::Jmx do
       }).and_return(nil)
 
       subject.register
-      Thread.new(subject) { sleep 0.5; subject.close } # force the plugin to exit
+      Thread.new(subject) { sleep 0.5; subject.do_stop } # force the plugin to exit
       subject.run(queue)
     end
 
@@ -122,7 +127,7 @@ describe LogStash::Inputs::Jmx do
       }).and_return(nil)
 
       subject.register
-      Thread.new(subject) { sleep 0.5; subject.close } # force the plugin to exit
+      Thread.new(subject) { sleep 0.5; subject.do_stop } # force the plugin to exit
       subject.run(queue)
     end
 
@@ -147,7 +152,7 @@ describe LogStash::Inputs::Jmx do
       }).and_return(nil)
 
       subject.register
-      Thread.new(subject) { sleep 0.5; subject.close } # force the plugin to exit
+      Thread.new(subject) { sleep 0.5; subject.do_stop } # force the plugin to exit
       subject.run(queue)
     end
   end


### PR DESCRIPTION
The jmx input plugin was not correctly handling the logstash shutdown using `do_stop` and `stop?` and `Stud.stoppable_sleep`. The symptom was to hang the logstash shutdown for some time. 

These are the minimal changes to make it correctly handle the logstash shutdown sequence. Note that this plugin would benefit a good refactor. 
